### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Any help is appreciated!
 
 ## Building with GNOME Builder
 
-The easiest methos, just follow [this guide](https://wiki.gnome.org/Newcomers/BuildProject), you'll be up and running in one minute.
+The easiest method, just follow [this guide](https://wiki.gnome.org/Newcomers/BuildProject), you'll be up and running in one minute.
 
 ## Building from Git
 


### PR DESCRIPTION
Fixed small typo "methos" to "method" in "Building with GNOME Builder" section